### PR TITLE
More softly fail based on `failIfNotFound` in `setOutputs`.

### DIFF
--- a/.github/workflows/add-pr-comment.yml
+++ b/.github/workflows/add-pr-comment.yml
@@ -10,7 +10,7 @@ jobs:
 
       - name: Find Pull Request
         id: find-pr
-        uses: kylorhall/find-github-pull-request@v0.0.3
+        uses: kylorhall/find-github-pull-request@v0.0.4
         with:
           failIfNotFound: true
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
 
       - name: Find Pull Request
         id: find-pr
-        uses: kylorhall/find-github-pull-request@v0.0.3
+        uses: kylorhall/find-github-pull-request@v0.0.4
         with:
           # These are all default values.
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -6358,7 +6358,7 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
 const findPullRequestFromSha = () => __awaiter(void 0, void 0, void 0, function* () {
     const githubToken = (0,core.getInput)('token', { required: false }); // not required unless for a search
     const allowClosed = (0,core.getBooleanInput)('allowClosed', { required: false });
-    const shouldFail = (0,core.getBooleanInput)('failIfNotFound', { required: false });
+    const failIfNotFound = (0,core.getBooleanInput)('failIfNotFound', { required: false });
     const currentSha = (0,core.getInput)('commitSha', { required: false });
     // To be honest, it shouldn't be able to fail here, due to `{ required: true }` (etc) above.
     if (!githubToken)
@@ -6378,7 +6378,7 @@ const findPullRequestFromSha = () => __awaiter(void 0, void 0, void 0, function*
         (0,core.debug)(`Filtered to find ${pullRequests.length} open pull requests.`);
     }
     if (!pullRequests.length) {
-        if (shouldFail) {
+        if (failIfNotFound) {
             (0,core.setFailed)(`No pull requests found for ${github.context.repo.owner}/${github.context.repo.repo}@${currentSha}, Github Action failed.`);
         }
         return;
@@ -6401,7 +6401,14 @@ const sanitize = (str) => str === null || str === void 0 ? void 0 : str.replace(
 
 const setOutputs = (pullRequest) => {
     if (!(pullRequest === null || pullRequest === void 0 ? void 0 : pullRequest.number)) {
-        (0,core.setFailed)(`We did not find a pull request for an event=${github.context.eventName}.`);
+        const failIfNotFound = (0,core.getBooleanInput)('failIfNotFound', {
+            required: false,
+        });
+        const message = `We did not find a pull request for an event=${github.context.eventName}.`;
+        if (failIfNotFound)
+            (0,core.setFailed)(message);
+        else
+            (0,core.debug)(message);
         return;
     }
     // Sanitize the title and body to avoid Shell interpolation of backticks and more.

--- a/jestHelpers.ts
+++ b/jestHelpers.ts
@@ -13,3 +13,36 @@ export const pullRequestFactory = (number: number, overrides?: object) => ({
   merged_at: '2021-09-06T07:08:38Z',
   ...overrides,
 });
+
+/** We put inputs into `process.env.INPUT_`.
+ * Provides a function to cleanup itself.
+ */
+export const setMockedInputs = (inputs: object) => {
+  const envKeyPairs = (Object.entries(inputs) as [string, string][]).map(
+    ([key, value]) => {
+      return [`INPUT_${key.replace(/ /g, '_').toUpperCase()}`, value];
+    }
+  );
+
+  envKeyPairs.forEach(([key, value]) => {
+    // don't set undefined values…
+    if (value !== undefined && value !== null) {
+      process.env[key] = String(value);
+    }
+  });
+
+  return {
+    deleteMockedInputs: () => {
+      envKeyPairs.forEach(([key]) => {
+        delete process.env[key];
+      });
+    },
+  };
+};
+
+/** We assume that anything at `process.env.INPUT_` is a mocked input. */
+export const deleteAllMockedInputs = () => {
+  Object.keys(process.env).forEach((key) => {
+    if (key.startsWith('INPUT_')) delete process.env[key];
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "find-github-pull-request",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "description": "Find a Github Pull Request in a Github Action",
   "main": "dist/index.js",
   "author": {

--- a/src/findPullRequestFromSha.ts
+++ b/src/findPullRequestFromSha.ts
@@ -4,7 +4,7 @@ import { getOctokit, context } from '@actions/github';
 export const findPullRequestFromSha = async () => {
   const githubToken = getInput('token', { required: false }); // not required unless for a search
   const allowClosed = getBooleanInput('allowClosed', { required: false });
-  const shouldFail = getBooleanInput('failIfNotFound', { required: false });
+  const failIfNotFound = getBooleanInput('failIfNotFound', { required: false });
   const currentSha = getInput('commitSha', { required: false });
 
   // To be honest, it shouldn't be able to fail here, due to `{ required: true }` (etc) above.
@@ -31,7 +31,7 @@ export const findPullRequestFromSha = async () => {
   }
 
   if (!pullRequests.length) {
-    if (shouldFail) {
+    if (failIfNotFound) {
       setFailed(
         `No pull requests found for ${context.repo.owner}/${context.repo.repo}@${currentSha}, Github Action failed.`
       );

--- a/src/setOutputs.ts
+++ b/src/setOutputs.ts
@@ -1,4 +1,4 @@
-import { setOutput, setFailed } from '@actions/core';
+import { debug, getBooleanInput, setOutput, setFailed } from '@actions/core';
 import { context } from '@actions/github';
 
 import { sanitize } from './sanitize';
@@ -7,9 +7,13 @@ import type { PullRequest } from './types';
 
 export const setOutputs = (pullRequest: PullRequest) => {
   if (!pullRequest?.number) {
-    setFailed(
-      `We did not find a pull request for an event=${context.eventName}.`
-    );
+    const failIfNotFound = getBooleanInput('failIfNotFound', {
+      required: false,
+    });
+
+    const message = `We did not find a pull request for an event=${context.eventName}.`;
+    if (failIfNotFound) setFailed(message);
+    else debug(message);
 
     return;
   }


### PR DESCRIPTION
 - Maintains 100% test coverage.
 - Bumps to v0.0.4