### PR TITLE
Allow Dependabot to pass a CI flow with a write permission on the PR Comment flow.

### DIFF
--- a/.github/workflows/add-pr-comment.yml
+++ b/.github/workflows/add-pr-comment.yml
@@ -2,6 +2,11 @@ name: Comment on Every Pull Request
 
 on: [push, pull_request]
 
+# NOTE: This is possibly insecure; it allows Dependabot to comment on a PR, the point of this run.
+# @see: https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/
+permissions:
+  pull-requests: write
+
 jobs:
   add-pr-comment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Without this, both `pull_request` ([example](https://github.com/kylorhall/find-github-pull-request/runs/4011707851?check_suite_focus=true)) and `push` ([example](https://github.com/kylorhall/find-github-pull-request/runs/4011707718?check_suite_focus=true)) triggers were failing due to `Resource not accessible by integration` because it doesn't have permission to comment on the pull request it finds.

I believe this fixes it, but it is technically a security hole (or annoyance) wherein someone could comment or modify a PR if they can sneak in something to gather the permission token.