### PR TITLE
Only fail to find the PR for a `pull_request` event, not `push`.

### DIFF
--- a/.github/workflows/add-pr-comment.yml
+++ b/.github/workflows/add-pr-comment.yml
@@ -12,7 +12,7 @@ jobs:
         id: find-pr
         uses: ./ # run against self
         with:
-          failIfNotFound: true
+          failIfNotFound: ${{ github.event_name == 'pull_request' }} # Fail for a PR, not for a push
 
       - name: Comment on the found Pull Request
         if: steps.find-pr.outputs.number != ''


### PR DESCRIPTION
On `push`, you will push the branch and a PR will not exist on the first push; it doesn't make sense to fail.  For `pull_request`, it does!