### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.1.0] - 2022-03-09
+
+ - [#95](https://github.com/sharesight/find-github-pull-request/pull/96) & [#96](https://github.com/sharesight/find-github-pull-request/pull/96) = Returning new outputs: `base-ref` and `base-sha`.
+    - This required additional functionality to fetch a full `pull_request` object via API, meaning `inputs.token` is now required.
+
 ## [1.0.1] - 2021-12-21
 
 - Added Dependabot

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
 
       - name: Find Pull Request
         id: find-pr
-        uses: kylorhall/find-github-pull-request@v1.0.1
+        uses: kylorhall/find-github-pull-request@1.1.0
         with:
           # These are all default values.
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -84,9 +84,8 @@ yarn jest:tdd
 
 1. Deicde on a semver, eg. `1.2.3`.
 2. Bump this version in `package.json` file—just for the sake of it.
-3. Bump this version in `.github/workflows/add-pr-comment.yml` file.
 4. Bump this version in `README.md` file.
-5. Run `yarn build` and commit that `dist/index.js` change.
+5. Ensure that `yarn build` already has been ran and a `dist/index.js` committed; commit if not.
 6. Version bumps should go via a PR and be merged into _master_ before releasing.
 
 #### Create the Release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "find-github-pull-request",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Find a Github Pull Request in a Github Action",
   "main": "dist/index.js",
   "author": {


### PR DESCRIPTION
**Changes:**
 - [#95](https://github.com/sharesight/find-github-pull-request/pull/96) & [#96](https://github.com/sharesight/find-github-pull-request/pull/96) = Returning new outputs: `base-ref` and `base-sha`.
  - This required additional functionality to fetch a full `pull_request` object via API, meaning `inputs.token` is now required.
 - Brief changes to the outdated README while I'm here.