### PR TITLE
Hotfix: Call the `fetchPr…` with `context.repo`!

### DIFF
--- a/__tests__/fetchPRByNumber.ts
+++ b/__tests__/fetchPRByNumber.ts
@@ -60,6 +60,8 @@ export const runTest = async (
   expect(getOctokit).toHaveBeenCalledWith(inputObj.token || '');
 
   expect(apiMock).toHaveBeenCalledTimes(1);
+  // These are mocked in our `@actions/github.context`:
+  expect(apiMock).toHaveBeenCalledWith({ owner: 'kylorhall', repo: 'repo', pull_number: 12345 });
 
   // Delete all `process.env.INPUT_PACKAGE` we just set.
   deleteMockedInputs();

--- a/__tests__/fetchPRBySha.ts
+++ b/__tests__/fetchPRBySha.ts
@@ -57,6 +57,8 @@ export const runTest = async (
   expect(getOctokit).toHaveBeenCalledWith(inputObj.token || '');
 
   expect(apiMock).toHaveBeenCalledTimes(1);
+  // These are mocked in our `@actions/github.context`:
+  expect(apiMock).toHaveBeenCalledWith({ owner: 'kylorhall', repo: 'repo', commit_sha: inputObj.commitSha || '' });
 
   // Delete all `process.env.INPUT_PACKAGE` we just set.
   deleteMockedInputs();

--- a/dist/index.js
+++ b/dist/index.js
@@ -8750,8 +8750,8 @@ const fetchPRByNumber = () => __awaiter(void 0, void 0, void 0, function* () {
     const octokit = (0,github.getOctokit)(githubToken);
     const number = github.context.payload.pull_request.number;
     const { data: pullRequest } = yield octokit.rest.pulls.get({
-        owner: "octokit",
-        repo: "rest.js",
+        owner: github.context.repo.owner,
+        repo: github.context.repo.repo,
         pull_number: number,
     });
     if (!pullRequest) {

--- a/src/fetchPRByNumber.ts
+++ b/src/fetchPRByNumber.ts
@@ -15,8 +15,8 @@ export const fetchPRByNumber = async (): Promise<PullRequest | undefined> => {
 
   const number = context.payload.pull_request.number;
   const { data: pullRequest } = await octokit.rest.pulls.get({
-    owner: "octokit",
-    repo: "rest.js",
+    owner: context.repo.owner,
+    repo: context.repo.repo,
     pull_number: number,
   });
 


### PR DESCRIPTION
Adds a lot of test coverage to do that as well.