### PR TITLE
Release v1.1.1: Fix `fetchByPr` to load from the right repo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.1.1] - 2022-03-09
+
+ - [#98](https://github.com/sharesight/find-github-pull-request/pull/98) - Fetch the PR with the correct `repo.owner`, `repo.repo`…not hardcoded to the documentation example.
+ - [#99](https://github.com/sharesight/find-github-pull-request/pull/99) - Run `yarn jest` while building.
+
 ## [1.1.0] - 2022-03-09
 
  - [#95](https://github.com/sharesight/find-github-pull-request/pull/96) & [#96](https://github.com/sharesight/find-github-pull-request/pull/96) = Returning new outputs: `base-ref` and `base-sha`.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
 
       - name: Find Pull Request
         id: find-pr
-        uses: kylorhall/find-github-pull-request@1.1.0
+        uses: kylorhall/find-github-pull-request@1.1.1
         with:
           # These are all default values.
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "find-github-pull-request",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Find a Github Pull Request in a Github Action",
   "main": "dist/index.js",
   "author": {


### PR DESCRIPTION
Changes:
- [#98](https://github.com/sharesight/find-github-pull-request/pull/98) - Fetch the PR with the correct `repo.owner`, `repo.repo`…not hardcoded to the documentation example.
 - [#99](https://github.com/sharesight/find-github-pull-request/pull/99) - Run `yarn jest` while building.